### PR TITLE
Layout: improve font rendering

### DIFF
--- a/src/pixelcard/app.py
+++ b/src/pixelcard/app.py
@@ -24,11 +24,27 @@ class PixelCard(Module):
         self.contact_info = contact_info
         self.font = font
 
+        text_margin = 4
+        self.font_settings = {
+            "text": _text,
+            "font": font,
+            "font_size": 20,
+            "bbox": (85.6 - text_margin * 2, 53.98 - text_margin * 2),
+            "scale_to_fit": True,
+            "pcb_offset": (text_margin, text_margin),
+        }
+
         # ----------------------------------------
         #     modules, interfaces, parameters
         # ----------------------------------------
         class _NODEs(Module.NODES()):
-            text = LEDText(text=_text, char_dimensions=(10 * 1.5, 14 * 1.5), font=font)
+            text = LEDText(
+                text=self.font_settings["text"],
+                font=self.font_settings["font"],
+                font_size=self.font_settings["font_size"],
+                bbox=self.font_settings["bbox"],
+                scale_to_fit=True,
+            )
             usb_psu = USB_C_5V_PSU_16p_Receptical()
             faebryk_logo = Faebryk_Logo()
 

--- a/src/pixelcard/modules/LEDText.py
+++ b/src/pixelcard/modules/LEDText.py
@@ -1,10 +1,7 @@
-from typing import Tuple
-
 from faebryk.core.core import Module
 from faebryk.exporters.pcb.layout.absolute import LayoutAbsolute
 from faebryk.exporters.pcb.layout.font import FontLayout
 from faebryk.exporters.pcb.layout.typehierarchy import LayoutTypeHierarchy
-from faebryk.library.Constant import Constant
 from faebryk.library.ElectricPower import ElectricPower
 from faebryk.library.has_pcb_layout_defined import has_pcb_layout_defined
 from faebryk.library.has_pcb_position import has_pcb_position
@@ -23,22 +20,23 @@ class LEDText(Module):
     def __init__(
         self,
         text: str,
-        char_dimensions: Tuple[float, float],
         font: Font,
+        font_size: float,
+        bbox: tuple[float, float] | None = None,
+        scale_to_fit: bool = False,
     ) -> None:
         super().__init__()
 
         led_layout = FontLayout(
             font=font,
             text=text,
-            char_dimensions=char_dimensions,
-            resolution=(0.33, 0.35),
-            # bbox=(10, 14),
-            kerning=5,
+            font_size=font_size,
+            density=0.2,
+            bbox=bbox,
+            scale_to_fit=scale_to_fit,
         )
 
         num_leds = led_layout.get_count()
-        self.char_dimension = char_dimensions
 
         class _IFs(Module.IFS()):
             power = ElectricPower()
@@ -53,9 +51,7 @@ class LEDText(Module):
 
         self.NODEs = _NODES(self)
 
-        class _PARAMs(Module.PARAMS()):
-            width = Constant(char_dimensions[0] * len(text))
-            height = Constant(char_dimensions[1])
+        class _PARAMs(Module.PARAMS()): ...
 
         self.PARAMs = _PARAMs(self)
 

--- a/src/pixelcard/pcb.py
+++ b/src/pixelcard/pcb.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from faebryk.core.graph import Graph
 from faebryk.core.util import get_all_nodes
-from faebryk.exporters.pcb.kicad.transformer import PCB_Transformer
+from faebryk.exporters.pcb.kicad.transformer import PCB_Transformer, Zone
 from faebryk.exporters.pcb.layout.absolute import LayoutAbsolute
 from faebryk.exporters.pcb.layout.typehierarchy import LayoutTypeHierarchy
 from faebryk.library.has_pcb_layout_defined import has_pcb_layout_defined
@@ -16,6 +16,7 @@ from faebryk.library.has_pcb_routing_strategy_via_to_layer import (
     has_pcb_routing_strategy_via_to_layer,
 )
 from faebryk.libs.app.pcb import apply_layouts, apply_routing
+from faebryk.libs.font import Font as Ffont
 from faebryk.libs.kicad.pcb import PCB, At, Font
 from pixelcard.app import PixelCard
 from pixelcard.library.Faebryk_Logo import Faebryk_Logo
@@ -49,6 +50,37 @@ def transform_pcb(pcb_file: Path, graph: Graph, app: PixelCard):
         remove_existing_outline=True,
     )
 
+    font = Ffont(app.font.path)
+
+    polygons = font.string_to_polygons(
+        app.font_settings["text"],
+        app.font_settings["font_size"],
+        bbox=app.font_settings["bbox"],
+        scale_to_fit=app.font_settings["scale_to_fit"],
+    )
+
+    for polygon in polygons:
+        transformer.insert(
+            Zone.factory(
+                net=0,
+                net_name="Text",
+                layer="F.SilkS",
+                uuid=transformer.gen_uuid(mark=True),
+                name="Text_polygon",
+                polygon=[
+                    (
+                        p[0] + app.font_settings["pcb_offset"][0],
+                        p[1] + app.font_settings["pcb_offset"][1],
+                    )
+                    for p in polygon.exterior.coords
+                ],
+            )
+        )
+
+    ledtext_height = (
+        max([p.bounds[3] for p in polygons]) + app.font_settings["pcb_offset"][1]
+    )
+
     # move all reference designators to the same position
     footprints = [
         cmp.get_trait(PCB_Transformer.has_linked_kicad_footprint).get_fp()
@@ -67,26 +99,6 @@ def transform_pcb(pcb_file: Path, graph: Graph, app: PixelCard):
     if "-Bold" in font_name:
         font_name, _ = font_name.split("-Bold")
         bold = True
-
-    TEXT_POS = (2, 2)
-
-    # TODO better trace actual font
-    # add text as silkscreen
-    # transformer.insert_text(
-    #    text=app.text,
-    #    at=At.factory(
-    #        (
-    #            -2.5 + TEXT_POS[0],
-    #            0.5 + TEXT_POS[1],
-    #        )
-    #    ),
-    #    font=Font.factory(
-    #        size=app.NODEs.text.char_dimension,
-    #        thickness=0.2,
-    #        bold=bold,
-    #        face=font_name,
-    #    ),
-    # )
 
     for i, line in enumerate(app.contact_info.split("\\n")):
         transformer.insert_text(
@@ -119,11 +131,6 @@ def transform_pcb(pcb_file: Path, graph: Graph, app: PixelCard):
     Point = has_pcb_position.Point
     L = has_pcb_position.layer_type
 
-    # TODO: ugly
-    for node in get_all_nodes(app):
-        if isinstance(node, LEDText):
-            # ledtext_width = node.PARAMs.width.value
-            ledtext_height = node.PARAMs.height.value
     app.add_trait(
         has_pcb_layout_defined(
             LayoutTypeHierarchy(
@@ -133,8 +140,8 @@ def transform_pcb(pcb_file: Path, graph: Graph, app: PixelCard):
                         layout=LayoutAbsolute(
                             Point(
                                 (
-                                    -7 + TEXT_POS[0],
-                                    1.5 + TEXT_POS[1],
+                                    0 + app.font_settings["pcb_offset"][0],
+                                    0 + app.font_settings["pcb_offset"][1],
                                     0,
                                     L.NONE,
                                 )
@@ -147,7 +154,8 @@ def transform_pcb(pcb_file: Path, graph: Graph, app: PixelCard):
                             Point(
                                 (
                                     creditcard_width - 4.5,
-                                    2 * ledtext_height + 2.5,
+                                    ledtext_height
+                                    + (creditcard_height - ledtext_height) / 2,
                                     90,
                                     L.NONE,
                                 )
@@ -160,7 +168,8 @@ def transform_pcb(pcb_file: Path, graph: Graph, app: PixelCard):
                             Point(
                                 (
                                     creditcard_width / 2,
-                                    creditcard_height / 2 + ledtext_height,
+                                    ledtext_height
+                                    + (creditcard_height - ledtext_height) / 2,
                                     0,
                                     L.NONE,
                                 )


### PR DESCRIPTION
Use updated FontLayout
Group font settings in app.py
Render silk zones for text polygons

Requires https://github.com/faebryk/faebryk/pull/208

With Minecraftia font:
![image](https://github.com/ruben-iteng/PixelCard/assets/3594253/882dc733-0e7d-49cd-884b-80705a409853)

![image](https://github.com/ruben-iteng/PixelCard/assets/3594253/22a23ce1-f2cd-4da7-a10d-beb7307cd38d)

With IBMPlexSans-Bold:
![image](https://github.com/ruben-iteng/PixelCard/assets/3594253/1af7d3e9-b9cc-42e0-b7d3-987ab7d3d792)


